### PR TITLE
EHN: Add support for `All Contributors` bot

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1,0 +1,16 @@
+{
+  "files": ["README.md"],
+  "imageSize": 100,
+  "contributorsPerLine": 7,
+  "badgeTemplate": "[![All Contributors](https://img.shields.io/badge/all_contributors-<%= contributors.length %>-orange.svg?style=flat-square)](#contributors)",
+  "contributorTemplate": "<%= avatarBlock %><br /><%= contributions %>",
+  "types": {
+    "custom": {
+      "symbol": "🔭",
+      "description": "A custom contribution type.",
+      "link": "[<%= symbol %>](<%= url %> \"<%= description %>\"),"
+    }
+  },
+  "skipCi": "true",
+  "contributors": []
+}


### PR DESCRIPTION
@all-contributors please add @norok2 for tool

See the official documentation of `All Contributors` on how to add a new contributor:
https://allcontributors.org/docs/en/bot/usage

For a list of "contribution types" see:
https://allcontributors.org/docs/en/emoji-key