### PR TITLE
Redirect to the new homepage of OSC Nijmegen

### DIFF
--- a/redirect/index.html
+++ b/redirect/index.html
@@ -1,0 +1,10 @@
+<html>
+<head>
+    <title>Open Science Community Nijmegen</title>
+    <meta http-equiv="refresh" content="0; URL=https://osc-international.com/osc-nijmegen/" />
+</head>
+
+<body>
+    <p>The Open Science Community Nijmegen homepage has moved. If you are not redirected automatically, follow this <a href="https://osc-international.com/osc-nijmegen/">link</a>.</p>
+</body>
+</html>


### PR DESCRIPTION
Anita Eerland has revived OSC Nijmegen, including a new online presence https://osc-international.com/osc-nijmegen/ under the umbrella of OSC International, with some funding from NWO, and a <a href="https://www.ru.nl/en/services/sport-culture-and-recreation/radboud-reflects/agenda/citizen-science-and-open-education-is-science-open-to-everyone">relaunch event</a> on 11 February 2025. On 10 December (=tomorrow) there will be an informal meet-up with drinks in the Radboud University Cultuurcafé.  

Anita asked me whether the old website could be updated. The domain name `openscience-nijmegen.nl` is configured to point to the website here that is hosted GitHub pages. I don't own the DNS registration for openscience-nijmegen.nl/ and cannot change the DNS records. This pull request adds an `index.html` page that is meant to replace the Jekyll website. The index page only contains a HTML meta redirect to the new webpage. 

In the GitHub configuration settings for Pages it is now specified that the website is built from the `docs` directory on the master branch. After merging this pull request, I will reconfigure that such that it is built from the `redirect` directory. The old website content remains available here on GitHub but will not be visible any more. Reverting to the old website could be done by changing the GitHub Pages configuration.
